### PR TITLE
fix wrong matlab librairy name for newer versions of matlab

### DIFF
--- a/JACO2Communicator/Source/JacoComm.m
+++ b/JACO2Communicator/Source/JacoComm.m
@@ -1,6 +1,6 @@
 classdef JacoComm < matlab.System & matlab.system.mixin.Propagates ...
         & matlab.system.mixin.CustomIcon ...
-        & matlab.system.mixin.internal.SampleTime
+        & matlab.system.mixin.SampleTime
     % JacoComm Send commands and read sensor data from Jaco robot
     %  See testJacoComm.m for examples of how to use the class.
     %  Copyright 2017 The MathWorks, Inc.


### PR DESCRIPTION
Resolves #10 

Librairy name is incorrect, creating an error when trying to use the arm after compiling.
```
The specified superclass 'matlab.system.mixin.internal.SampleTime' contains a parse error, cannot be found
on MATLAB's search path, or is shadowed by another file with the same name.
```